### PR TITLE
Fix handling of hostnames for TLS and in callbacks

### DIFF
--- a/src/main/java/com/wire/bots/roman/Tools.java
+++ b/src/main/java/com/wire/bots/roman/Tools.java
@@ -11,6 +11,8 @@ import java.security.cert.Certificate;
 import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class Tools {
 
@@ -42,7 +44,8 @@ public class Tools {
 
     public static String getPubkey(String hostname) throws IOException {
         String str = null;
-        PublicKey publicKey = getPublicKey(hostname);
+        String raw_hostname = URI.create(hostname).getHost();
+        PublicKey publicKey = getPublicKey(raw_hostname);
         if (publicKey != null)
             str = Base64.getEncoder().encodeToString(publicKey.getEncoded());
         final String start = "-----BEGIN PUBLIC KEY-----";

--- a/src/main/java/com/wire/bots/roman/resources/ServiceResource.java
+++ b/src/main/java/com/wire/bots/roman/resources/ServiceResource.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Base64;
 import java.util.UUID;
@@ -276,9 +277,9 @@ public class ServiceResource {
             if (url == null)
                 return true;
             try {
-                new URL(url);
-                return url.contains(".");
-            } catch (MalformedURLException e) {
+                new URL(url).toURI();
+                return true;
+            } catch (URISyntaxException | MalformedURLException e) {
                 return false;
             }
         }
@@ -300,11 +301,10 @@ public class ServiceResource {
         public boolean isUrlValid() {
             if (url == null)
                 return true;
-
             try {
-                new URL(url);
-                return url.contains(".");
-            } catch (MalformedURLException e) {
+                new URL(url).toURI();
+                return true;
+            } catch (URISyntaxException | MalformedURLException e) {
                 return false;
             }
         }


### PR DESCRIPTION
Thanks for your great work on this proxy library. It makes it much easier to implement applications without dealing with the complexity of handling end-to-end encrypted messages directly.

This PR fixes two issues that I have encountered when trying to create a custom web application which uses roman.

**Using hostname for TLS cert fetch**

The first is that in `model/Service.java` the `baseUrl` attribute expects a domain name which includes a `http(s)` schema, but that domain is also passed to `Tools.getPubkey` which expects a raw hostname without a schema. The hostname is then used to fetch the TLS certificate for that host.

```java
summary = "Summary";
description = "Description";
tags = new String[]{"tutorial"};
baseUrl = String.format("%s/proxy", config.domain);
pubkey = Tools.getPubkey(config.domain);
```

Your example yaml config file also defines `DOMAIN` with a schema.

```yaml
domain: ${DOMAIN:-https://services.wire.com}
```

My fix parses the URI in getPubkey and extracts the raw hostname to use in the `createSocket` call.

**Allow DNS name without dot character for callback**

I'm using `docker-compose` to deploy my custom web application with the Roman proxy. Docker automatically sets up a hostname `app` for the container when deployed. I want roman to be able to send callbacks to that container at `http://app/callback` over the Docker internal network. 

```java
if (url == null)
    return true;
try {
   new URL(url);
    return url.contains(".");
} catch (MalformedURLException e) {
    return false;
}
```

The current code checks explicitly for a dot character in the hostname. A dot is not needed to make a valid hostname. Can you make this optional if you only need this for the `https://services.wire.com` deployment.
