### PR TITLE
Add extra fields in events

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ wss://services.wire.com/proxy/await/`<app_key>`
     "userId": "4dfc5c70-dcc8-4d9e-82be-a3cbe6661107", // User who requested this bot
     "handle": "dejan_wire", // username of the user who requested this bot
     "locale": "en_US"       // locale of the user who requested this bot
+    "token": "..."          // Use this token to make outbound requests to the Wire API server
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Your service must be available at the moment `bot_request` event is sent. It mus
     "type": "conversation.init",
     "botId": "216efc31-d483-4bd6-aec7-4adc2da50ca5",
     "userId": "4dfc5c70-dcc8-4d9e-82be-a3cbe6661107", // User who added this bot into conversation
+    "conversationId": "6e546250-35d2-4e79-a3d7-1dc36962a9cc",  // UUID of the conversation
     "token": "...",                                   // Access token. Store this token so the bot can post back later
     "text": "Bot Example Conversation"                // Conversation name
 }

--- a/src/main/java/com/wire/bots/roman/MessageHandler.java
+++ b/src/main/java/com/wire/bots/roman/MessageHandler.java
@@ -54,6 +54,7 @@ public class MessageHandler extends MessageHandlerBase {
         message.userId = newBot.origin.id;
         message.handle = newBot.origin.handle;
         message.locale = newBot.locale;
+        message.token = newBot.token;
 
         message.type = "conversation.bot_request";
 

--- a/src/main/java/com/wire/bots/roman/MessageHandler.java
+++ b/src/main/java/com/wire/bots/roman/MessageHandler.java
@@ -68,6 +68,7 @@ public class MessageHandler extends MessageHandlerBase {
         message.botId = botId;
         message.userId = msg.from;
         message.type = "conversation.init";
+        message.conversationId = msg.conversation.id;
         message.text = msg.conversation.name;
         message.token = generateToken(botId);
 

--- a/src/main/java/com/wire/bots/roman/model/OutgoingMessage.java
+++ b/src/main/java/com/wire/bots/roman/model/OutgoingMessage.java
@@ -23,4 +23,5 @@ public class OutgoingMessage {
     public String image;
     public String handle;
     public String locale;
+    public UUID conversationId;
 }


### PR DESCRIPTION
This  PR adds some extra fields to the the callback payloads. I need my external application to receive the outbound auth token in the `bot_request` event. This allows the bot to directly retrieve info about itself and the members of its conversation.

I have also added the `conversationId` to the `conversation.init` event to allow the bot to track which conversations it has been added to, and to direct messages to a particular conversation rather than a particular bot instance.