### PR TITLE
Wire notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI/CD
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,14 @@ jobs:
           add_git_labels: true
           # push only if this is develop branch
           push: ${{ startsWith(github.ref, 'refs/heads/develop') }}
+
+      # Send webhook to Wire using Slack Bot
+      - name: Webhook to Wire
+        uses: 8398a7/action-slack@v2
+        with:
+          status: ${{ job.status }}
+          author_name: Roman CI pipeline
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_CI }}
+        # Send message only if previous step failed
+        if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,14 @@ jobs:
           add_git_labels: true
           # push only if this is tagged release
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+      # Send webhook to Wire using Slack Bot
+      - name: Webhook to Wire
+        uses: 8398a7/action-slack@v2
+        with:
+          status: ${{ job.status }}
+          author_name: Roman Release Pipeline
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_RELEASE }}
+        # Notify every release
+        if: always()


### PR DESCRIPTION
Pipelines are set in similar way as for Charon.

1) release pipeline will always send notification to wire conversation
1) CI pipeline only if the build failed (in order not to be too noisy)

Two things must be done:
1) create conversation in Wire and add Github Actions bot - it will generate webhook
1) create secret in this repo with names `WEBHOOK_CI` and `WEBHOOK_RELEASE` - value is then generated URL 